### PR TITLE
Replace intro-skipper manifest URL

### DIFF
--- a/sources.txt
+++ b/sources.txt
@@ -2,7 +2,7 @@ https://app.lizardbyte.dev/jellyfin-plugin-repo/manifest.json
 https://github.com/cxfksword/jellyfin-plugin-danmu/releases/download/manifest/manifest.json
 https://github.com/cxfksword/jellyfin-plugin-metashark/releases/download/manifest/manifest.json
 https://github.com/lachlandcp/jellyfin-editors-choice-plugin/raw/main/manifest.json
-https://intro-skipper.org/manifest.json
+https://raw.githubusercontent.com/intro-skipper/manifest/refs/heads/main/10.11/manifest.json
 https://jellyfin-repo.jesseward.com/manifest.json
 https://kookxiang.github.io/jellyfin-plugin-bangumi/repository.json
 https://noonamer.github.io/Jellyfin.Plugin.LocalPosters/repository.json

--- a/sources.txt
+++ b/sources.txt
@@ -1,8 +1,8 @@
+# https://raw.githubusercontent.com/shemanaev/jellyfin-plugin-repo/master/manifest.json
 https://app.lizardbyte.dev/jellyfin-plugin-repo/manifest.json
 https://github.com/cxfksword/jellyfin-plugin-danmu/releases/download/manifest/manifest.json
 https://github.com/cxfksword/jellyfin-plugin-metashark/releases/download/manifest/manifest.json
 https://github.com/lachlandcp/jellyfin-editors-choice-plugin/raw/main/manifest.json
-https://raw.githubusercontent.com/intro-skipper/manifest/refs/heads/main/10.11/manifest.json
 https://jellyfin-repo.jesseward.com/manifest.json
 https://kookxiang.github.io/jellyfin-plugin-bangumi/repository.json
 https://noonamer.github.io/Jellyfin.Plugin.LocalPosters/repository.json
@@ -18,9 +18,11 @@ https://raw.githubusercontent.com/Felitendo/jellyfin-plugin-lyrics/master/manife
 https://raw.githubusercontent.com/GrandguyJS/media-upload-plugin/main/manifest.json
 https://raw.githubusercontent.com/iankiller77/MyAnimeSync/main/manifest.json
 https://raw.githubusercontent.com/ImLacy/Jellyfin-CustomLogo/refs/heads/main/manifest.json
+https://raw.githubusercontent.com/intro-skipper/manifest/refs/heads/main/10.11/manifest.json
 https://raw.githubusercontent.com/johnpc/jellyfin-plugin-smart-collections/refs/heads/main/manifest.json
 https://raw.githubusercontent.com/jon4hz/jellyfin-plugin-jellysleep/main/manifest.json
 https://raw.githubusercontent.com/KeksBombe/jellyfin-plugin-auto-collections/refs/heads/main/manifest.json
+https://raw.githubusercontent.com/lostb1t/Gelato/refs/heads/gh-pages/repository.json
 https://raw.githubusercontent.com/lostb1t/jellyfin-plugin-collection-import/main/manifest.json
 https://raw.githubusercontent.com/metatube-community/jellyfin-plugin-metatube/dist/manifest.json
 https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json
@@ -28,7 +30,6 @@ https://raw.githubusercontent.com/Namo2/InPlayerEpisodePreview/master/manifest.j
 https://raw.githubusercontent.com/nikarh/jellyfin-plugin-authelia/main/manifest.json
 https://raw.githubusercontent.com/RomainPierre7/jellyfin-plugin-TelegramNotifier/main/manifest.json
 https://raw.githubusercontent.com/ryandash/jellyfin-plugin-myanimelist/main/manifest.json
-# https://raw.githubusercontent.com/shemanaev/jellyfin-plugin-repo/master/manifest.json
 https://raw.githubusercontent.com/ShokoAnime/Shokofin/metadata/stable/manifest.json
 https://raw.githubusercontent.com/streamyfin/jellyfin-plugin-streamyfin/main/manifest.json
 https://raw.githubusercontent.com/ThePornDatabase/Jellyfin.Plugin.ThePornDB/main/manifest.json
@@ -41,4 +42,3 @@ https://repo.xkrivo.net/jellyfin/manifest.json
 https://simoni.dev/jellyfin/repo.json
 https://www.iamparadox.dev/jellyfin/plugins/manifest.json
 https://xzonn.top/JellyfinPluginDouban/manifest.json
-https://raw.githubusercontent.com/lostb1t/Gelato/refs/heads/gh-pages/repository.json


### PR DESCRIPTION
The direct source should be used because you always serve for example 10.11. The purpose of the redirect, which is based on the Jellyfin version, is to direct users to the correct installer manifest. It is possible to install the 10.10 version on 10.11. However, the plugin will not work after a reboot. It was a massive problem in the past. 

### Feature / Bug fixes:

1. [x] Have you ran update.js and pushed the resulting manifest to your forks repo?

2. [x] Have you added the generated manifest from your fork to verify functionality?

### Adding sources:

1. [x] Have you removed any duplicate sources?

 - VSCode: ctrl + shift + p > Delete Duplicate Lines

2. [x] Have you sorted lines by ascending?

 - VSCode: ctrl + shift + p > Sort Lines Ascending

3. [x] If you are adding a source: is it a fork of an existing plugin?
