### PR TITLE
Add Quality Gate plugin source

### DIFF
--- a/sources.txt
+++ b/sources.txt
@@ -22,6 +22,7 @@ https://raw.githubusercontent.com/enoch85/bazarr-jellyfin/main/manifest.json
 https://raw.githubusercontent.com/Felitendo/jellyfin-plugin-lyrics/master/manifest.json
 https://raw.githubusercontent.com/Fovty/HoverTrailer/master/manifest.json
 https://raw.githubusercontent.com/G-grbz/Jellyfin-MonWUI-Plugin/main/manifest.json
+https://raw.githubusercontent.com/GeiserX/quality-gate/main/manifest.json
 https://raw.githubusercontent.com/GeiserX/smart-covers/main/manifest.json
 https://raw.githubusercontent.com/GrandguyJS/media-upload-plugin/main/manifest.json
 https://raw.githubusercontent.com/iankiller77/MyAnimeSync/main/manifest.json


### PR DESCRIPTION
Adds the manifest URL for [Quality Gate](https://github.com/GeiserX/quality-gate), a Jellyfin plugin that restricts users to specific media versions based on configurable path-based policies.

Manifest: `https://raw.githubusercontent.com/GeiserX/quality-gate/main/manifest.json`

*My other plugins [smart-covers](https://github.com/GeiserX/smart-covers) and [whisper-subs](https://github.com/GeiserX/whisper-subs) are already included.*