### PR TITLE
Add JellyProfiles

### DIFF
--- a/sources.txt
+++ b/sources.txt
@@ -8,6 +8,7 @@
 # 8                          ^
 # 9      version will usually be *.* to match any
 # 91     supports comma separation for each exclusive match: 10.10,10.11,12.0
+https://ahouseofbards.github.io/Bonfire-JellyProfiles/manifest.json | https://github.com/AHouseOfBards/Bonfire-JellyProfiles | *.*
 https://app.lizardbyte.dev/jellyfin-plugin-repo/manifest.json | https://github.com/LizardByte/jellyfin-plugin-repo | *.*
 https://baeac.xyz/jellyfin/plugins/manifest.json | https://github.com/21513/Jellyfeatured | *.*
 https://baywolf-studios.github.io/jellyfin-plugin-repo/manifest.json | https://github.com/baywolf-studios/jellyfin-plugin-repo | *.*


### PR DESCRIPTION
### Adding sources:

Plugin Source: https://ahouseofbards.github.io/Bonfire-JellyProfiles/manifest.json

Plugin Repo URL: https://github.com/AHouseOfBards/Bonfire-JellyProfiles

1. [x] Have you sorted the sources.txt file alphabetically?

2. [x] Have you deleted duplicate lines in sources.txt?

3. [x] Have you checked if the plugin already exists in the Jellyfin Catalogue?