### PR TITLE
Add Posterizarr Plugin

### DIFF
--- a/sources.txt
+++ b/sources.txt
@@ -67,7 +67,7 @@ https://raw.githubusercontent.com/Felitendo/jellyfin-plugin-lyrics/master/manife
 https://raw.githubusercontent.com/felixfoertsch/jellyfin-sponsorblock/main/manifest.json |https://github.com/felixfoertsch/jellyfin-sponsorblock *.*
 https://raw.githubusercontent.com/Fovty/HoverTrailer/master/manifest.json | https://github.com/Fovty/HoverTrailer | *.*
 https://raw.githubusercontent.com/foxtrotdev/jellyfin-plugin-audio-flags/main/manifest.json | https://github.com/foxtrotdev/jellyfin-plugin-audio-flags | *.*
-https://raw.githubusercontent.com/fscorrupt/posterizarr/main/manifest.json | https://github.com/fscorrupt/posterizarr | 10.11,12.0
+https://raw.githubusercontent.com/fscorrupt/posterizarr/main/manifest.json | https://github.com/fscorrupt/posterizarr | *.*
 https://raw.githubusercontent.com/G-grbz/Jellyfin-MonWUI-Plugin/main/manifest.json | https://github.com/G-grbz/Jellyfin-MonWUI-Plugin | *.*
 https://raw.githubusercontent.com/GrandguyJS/media-upload-plugin/main/manifest.json | https://github.com/GrandguyJS/media-upload-plugin | *.*
 https://raw.githubusercontent.com/HarshLabs/jellyfin-plugin-native-trickplay/main/manifest.json | https://github.com/HarshLabs/jellyfin-plugin-native-trickplay | *.*

--- a/sources.txt
+++ b/sources.txt
@@ -67,6 +67,7 @@ https://raw.githubusercontent.com/Felitendo/jellyfin-plugin-lyrics/master/manife
 https://raw.githubusercontent.com/felixfoertsch/jellyfin-sponsorblock/main/manifest.json |https://github.com/felixfoertsch/jellyfin-sponsorblock *.*
 https://raw.githubusercontent.com/Fovty/HoverTrailer/master/manifest.json | https://github.com/Fovty/HoverTrailer | *.*
 https://raw.githubusercontent.com/foxtrotdev/jellyfin-plugin-audio-flags/main/manifest.json | https://github.com/foxtrotdev/jellyfin-plugin-audio-flags | *.*
+https://raw.githubusercontent.com/fscorrupt/posterizarr/main/manifest.json | https://github.com/fscorrupt/posterizarr | 10.11,12.0
 https://raw.githubusercontent.com/G-grbz/Jellyfin-MonWUI-Plugin/main/manifest.json | https://github.com/G-grbz/Jellyfin-MonWUI-Plugin | *.*
 https://raw.githubusercontent.com/GrandguyJS/media-upload-plugin/main/manifest.json | https://github.com/GrandguyJS/media-upload-plugin | *.*
 https://raw.githubusercontent.com/HarshLabs/jellyfin-plugin-native-trickplay/main/manifest.json | https://github.com/HarshLabs/jellyfin-plugin-native-trickplay | *.*


### PR DESCRIPTION
### Adding sources: Posterizarr 

Plugin Source: https://raw.githubusercontent.com/fscorrupt/posterizarr/main/manifest.json

Plugin Repo URL: https://github.com/fscorrupt/posterizarr

1. [x] Have you sorted the sources.txt file alphabetically?

2. [x] Have you deleted duplicate lines in sources.txt?

3. [x] Have you checked if the plugin already exists in the Jellyfin Catalogue?