### PR TITLE
Add Jellyfin Plugin Group Repository

### DIFF
--- a/sources.txt
+++ b/sources.txt
@@ -79,6 +79,7 @@ https://raw.githubusercontent.com/iHumberto/jellyfin-plugin-scriptrunner/main/ma
 https://raw.githubusercontent.com/ImLunaHey/jellyfin-plugin-brrr-now/main/manifest.json | https://github.com/ImLunaHey/jellyfin-plugin-brrr-now | *.*
 https://raw.githubusercontent.com/ImLunaHey/jellyfin-plugin-brrr-now/main/manifest.json | https://github.com/ImLunaHey/jellyfin-plugin-brrr-now | 10.10
 https://raw.githubusercontent.com/JellyboxAD/Jellyfin.Plugin.StreamLimit/main/manifest.json | https://github.com/JellyboxAD/Jellyfin.Plugin.StreamLimit | *.*
+https://raw.githubusercontent.com/Jellyfin-PG/Repository/refs/heads/main/manifest.json | https://github.com/Jellyfin-PG/JellyEmu | *.*
 https://raw.githubusercontent.com/jellystrm/plugins/main/manifest.json | https://github.com/jellystrm/plugins | *.*
 https://raw.githubusercontent.com/john-pierre/jellyfin-plugin-tvheadend-api/refs/heads/main/manifest.json | https://github.com/john-pierre/jellyfin-plugin-tvheadend-api | *.*
 https://raw.githubusercontent.com/johnpc/jellyfin-plugin-smart-collections/refs/heads/main/manifest.json | https://github.com/johnpc/jellyfin-plugin-smart-collections/ | *.*


### PR DESCRIPTION
This adds the [Jellyfin Plugin Group](https://github.com/Jellyfin-PG/Repository) manifest. It includes plugins like [JellyEmu](https://github.com/Jellyfin-PG/JellyEmu).
### Adding sources:

Plugin Source: https://github.com/Jellyfin-PG/Repository

1. [x] Have you sorted the sources.txt file alphabetically?

2. [x] Have you deleted duplicate lines in sources.txt?

3. [x] Have you checked if the plugin already exists in the Jellyfin Catalogue?
